### PR TITLE
Fixed the issue 'When the path includes a blank character, build using the batch file fails'

### DIFF
--- a/root_VS2015/programs/C#/10_Build_WebApp_sample.bat
+++ b/root_VS2015/programs/C#/10_Build_WebApp_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/11_Build_silverlight_sample.bat
+++ b/root_VS2015/programs/C#/11_Build_silverlight_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/12_Build_WinStore_sample.bat
+++ b/root_VS2015/programs/C#/12_Build_WinStore_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/3_Build_Framework.bat
+++ b/root_VS2015/programs/C#/3_Build_Framework.bat
@@ -8,7 +8,7 @@ setlocal
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/3_Build_PortableClassLibrary.bat
+++ b/root_VS2015/programs/C#/3_Build_PortableClassLibrary.bat
@@ -8,7 +8,7 @@ setlocal
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/3_Build_RichClientCustomControl.bat
+++ b/root_VS2015/programs/C#/3_Build_RichClientCustomControl.bat
@@ -8,7 +8,7 @@ setlocal
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/4_Build_Framework_Tool.bat
+++ b/root_VS2015/programs/C#/4_Build_Framework_Tool.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/5_Build_2CS_sample.bat
+++ b/root_VS2015/programs/C#/5_Build_2CS_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/5_Build_Bat_sample.bat
+++ b/root_VS2015/programs/C#/5_Build_Bat_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/6_Build_WSSrv_sample.bat
+++ b/root_VS2015/programs/C#/6_Build_WSSrv_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/7_Build_Framework_WS.bat
+++ b/root_VS2015/programs/C#/7_Build_Framework_WS.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/8_Build_WSClnt_sample.bat
+++ b/root_VS2015/programs/C#/8_Build_WSClnt_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/C#/9_Build_WSClnt_sample.bat
+++ b/root_VS2015/programs/C#/9_Build_WSClnt_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/10_Build_WebApp_sample.bat
+++ b/root_VS2015/programs/VB/10_Build_WebApp_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/3_Build_Framework.bat
+++ b/root_VS2015/programs/VB/3_Build_Framework.bat
@@ -8,7 +8,7 @@ setlocal
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/3_Build_RichClientCustomControl.bat
+++ b/root_VS2015/programs/VB/3_Build_RichClientCustomControl.bat
@@ -8,7 +8,7 @@ setlocal
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/5_Build_2CS_sample.bat
+++ b/root_VS2015/programs/VB/5_Build_2CS_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/5_Build_Bat_sample.bat
+++ b/root_VS2015/programs/VB/5_Build_Bat_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/6_Build_WSSrv_sample.bat
+++ b/root_VS2015/programs/VB/6_Build_WSSrv_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/7_Build_Framework_WS.bat
+++ b/root_VS2015/programs/VB/7_Build_Framework_WS.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.

--- a/root_VS2015/programs/VB/8_Build_WSClnt_sample.bat
+++ b/root_VS2015/programs/VB/8_Build_WSClnt_sample.bat
@@ -13,7 +13,7 @@ set ORG_PATH=%PATH%
 @rem --------------------------------------------------
 @rem Get the path to the executable file.
 @rem --------------------------------------------------
-set CURRENT_DIR=%~dp0
+set CURRENT_DIR="%~dp0"
 
 @rem --------------------------------------------------
 @rem Execution of the common processing.


### PR DESCRIPTION
Fixed the issue 'When the path includes a blank character, build using the batch file fails'

https://github.com/OpenTouryoProject/OpenTouryo/issues/146