### PR TITLE
Introduced a new file TMProtocolDefinition2 to resolve the URL issue in the CallController.

### DIFF
--- a/root_VS2013/files/resource/Xml/TMProtocolDefinition2.xml
+++ b/root_VS2013/files/resource/Xml/TMProtocolDefinition2.xml
@@ -17,7 +17,9 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
+		<Url id="url_b" value="http://localhost:8888/WCFHTTPSvcForFx.svc"/>
+		<Url id="url_c" value="net.tcp://localhost:7777/WCFTCPSvcForFx/"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -27,9 +29,13 @@
 		<!-- インプロセス -->
 		<Transmission id="testInProcess" protocol="1"/>
 
-		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<!-- サービス -->
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService2" protocol="3" url="http://localhost:8888/WCFHTTPSvcForFx.svc" />
+		<Transmission id="testWebService3" protocol="4" url="net.tcp://localhost:7777/WCFTCPSvcForFx/" />
 		
-		<!-- Webサービス（マスタ データを活用）-->
+		<!-- サービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />
+		<Transmission id="_testWebService2" protocol="3" url_ref="url_b" />
+		<Transmission id="_testWebService3" protocol="4" url_ref="url_c" />
 </TMD>

--- a/root_VS2013/programs/C#/Frameworks/Infrastructure/ServiceInterface/AsyncProcessingService/AsyncProcessingService.csproj
+++ b/root_VS2013/programs/C#/Frameworks/Infrastructure/ServiceInterface/AsyncProcessingService/AsyncProcessingService.csproj
@@ -87,7 +87,11 @@
   <ItemGroup>
     <None Include="app.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <EmbeddedResource Include="TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/root_VS2013/programs/C#/Frameworks/Infrastructure/ServiceInterface/AsyncProcessingService/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/C#/Frameworks/Infrastructure/ServiceInterface/AsyncProcessingService/TMProtocolDefinition2.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE TMD[
+  <!ELEMENT TMD (Prop*, Url*, Transmission*)>
+
+  <!ELEMENT Url EMPTY>
+  <!ELEMENT Prop EMPTY>
+  <!ELEMENT Transmission EMPTY>
+
+  <!ATTLIST Url id ID #REQUIRED value CDATA #REQUIRED>
+  <!ATTLIST Prop id ID #REQUIRED value CDATA #REQUIRED>
+  <!ATTLIST Transmission id ID #REQUIRED protocol (1 | 2) #REQUIRED 
+		url CDATA #IMPLIED url_ref IDREF #IMPLIED timeout CDATA #IMPLIED prop_ref IDREF #IMPLIED>
+]>
+<!-- idの先頭には、数字を使用できない。 -->
+<!-- protocol：1=InProcess、2=WebService -->
+<TMD>
+  <!-- マスタ データ -->
+
+  <!-- 接続URL（asmx単位に定義する） -->
+  <Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
+  <Url id="url_b" value="http://localhost:8888/WCFHTTPSvcForFx.svc"/>
+  <Url id="url_c" value="net.tcp://localhost:7777/WCFTCPSvcForFx/"/>
+
+  <!-- 接続オプション（必要に応じて） -->
+  <Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
+
+  <!-- 接続先 データ -->
+
+  <!-- インプロセス -->
+  <Transmission id="AzureStrageCopy" protocol="1"/>
+</TMD>

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/WSClientWPF_sample.csproj
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/WSClientWPF_sample.csproj
@@ -160,6 +160,9 @@
     <EmbeddedResource Include="TMProtocolDefinition.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
+	<EmbeddedResource Include="TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="SampleLogConf2CS.xml">

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/WSClientWin2_sample.csproj
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/WSClientWin2_sample.csproj
@@ -212,6 +212,11 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="config\TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWinCone_sample/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWinCone_sample/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWinCone_sample/WSClientWinCone_sample.csproj
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWinCone_sample/WSClientWinCone_sample.csproj
@@ -158,6 +158,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TMProtocolDefinition2.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/WSClientWin_sample.csproj
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/WSClientWin_sample.csproj
@@ -169,6 +169,11 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/root_VS2013/programs/C#/Samples/WinAzure_sample/ASPNETWebService/ASPNETWebService.csproj
+++ b/root_VS2013/programs/C#/Samples/WinAzure_sample/ASPNETWebService/ASPNETWebService.csproj
@@ -177,6 +177,9 @@
     <EmbeddedResource Include="..\resource\Xml\TMProtocolDefinition.xml">
       <Link>XML\TMProtocolDefinition.xml</Link>
     </EmbeddedResource>
+    <EmbeddedResource Include="..\resource\Xml\TMProtocolDefinition2.xml">
+      <Link>XML\TMProtocolDefinition2.xml</Link>
+    </EmbeddedResource>
     <Content Include="ServiceForAuth.asmx" />
     <Content Include="ServiceForFx.asmx" />
     <Content Include="Web.config" />

--- a/root_VS2013/programs/C#/Samples/WinAzure_sample/resource/Xml/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/C#/Samples/WinAzure_sample/resource/Xml/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/WSClientWPF_sample.vbproj
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/WSClientWPF_sample.vbproj
@@ -132,6 +132,9 @@
     <EmbeddedResource Include="TMProtocolDefinition.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
+	<EmbeddedResource Include="TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="Application.xaml">

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/WSClientWin2_sample.vbproj
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/WSClientWin2_sample.vbproj
@@ -219,6 +219,11 @@
       <Install>true</Install>
     </BootstrapperPackage>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="config\TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition2.xml
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition2.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost:8888/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/WSClientWin_sample.vbproj
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/WSClientWin_sample.vbproj
@@ -145,6 +145,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Blue hills.jpg" />
+    <EmbeddedResource Include="TMProtocolDefinition2.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="TMInProcessDefinition.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>


### PR DESCRIPTION
To overcome the URI issue, we are maintaining the following two kind of protocol definition XML files.
- TMProtocolDefinition.xml (having project name)
- TMProtocolDefinition2.xml (not having project name)

Users use this function by switching these two files by setting of app.config.
