### PR TITLE
Removed port number of web service URL in the TMProtocolDefinition file

### DIFF
--- a/root_VS2013/files/resource/Xml/TMProtocolDefinition.xml
+++ b/root_VS2013/files/resource/Xml/TMProtocolDefinition.xml
@@ -17,8 +17,8 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
-		<Url id="url_b" value="http://localhost:8888/ASPNETWebService/WCFHTTPSvcForFx.svc"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_b" value="http://localhost/ASPNETWebService/WCFHTTPSvcForFx.svc"/>
 		<Url id="url_c" value="net.tcp://localhost:7777/WCFService/WCFTCPSvcForFx/"/>
 
 		<!-- 接続オプション（必要に応じて） -->
@@ -30,8 +30,8 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- サービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
-		<Transmission id="testWebService2" protocol="3" url="http://localhost:8888/ASPNETWebService/WCFHTTPSvcForFx.svc" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService2" protocol="3" url="http://localhost/ASPNETWebService/WCFHTTPSvcForFx.svc" />
 		<Transmission id="testWebService3" protocol="4" url="net.tcp://localhost:7777/WCFService/WCFTCPSvcForFx/" />
 		
 		<!-- サービス（マスタ データを活用）-->

--- a/root_VS2013/programs/C#/Frameworks/Infrastructure/ServiceInterface/AsyncProcessingService/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/C#/Frameworks/Infrastructure/ServiceInterface/AsyncProcessingService/TMProtocolDefinition.xml
@@ -17,8 +17,8 @@
   <!-- マスタ データ -->
 
   <!-- 接続URL（asmx単位に定義する） -->
-  <Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
-  <Url id="url_b" value="http://localhost:8888/ASPNETWebService/WCFHTTPSvcForFx.svc"/>
+  <Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
+  <Url id="url_b" value="http://localhost/ASPNETWebService/WCFHTTPSvcForFx.svc"/>
   <Url id="url_c" value="net.tcp://localhost:7777/WCFService/WCFTCPSvcForFx/"/>
 
   <!-- 接続オプション（必要に応じて） -->

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWinCone_sample/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWinCone_sample/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/C#/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/C#/Samples/WinAzure_sample/resource/Xml/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/C#/Samples/WinAzure_sample/resource/Xml/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWPF_sample/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin2_sample/config/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />

--- a/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition.xml
+++ b/root_VS2013/programs/VB/Samples/WS_sample/WSClient_sample/WSClientWin_sample/TMProtocolDefinition.xml
@@ -17,7 +17,7 @@
 	<!-- マスタ データ -->
 
 		<!-- 接続URL（asmx単位に定義する） -->
-		<Url id="url_a" value="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx"/>
+		<Url id="url_a" value="http://localhost/ASPNETWebService/ServiceForFx.asmx"/>
 
 		<!-- 接続オプション（必要に応じて） -->
 		<Prop id="prop_a" value="aaa=AAA;bbb=BBB;ccc=CCC;"/>
@@ -28,7 +28,7 @@
 		<Transmission id="testInProcess" protocol="1"/>
 
 		<!-- Webサービス -->
-		<Transmission id="testWebService" protocol="2" url="http://localhost:8888/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
+		<Transmission id="testWebService" protocol="2" url="http://localhost/ASPNETWebService/ServiceForFx.asmx" timeout="60" />
 		
 		<!-- Webサービス（マスタ データを活用）-->
 		<Transmission id="_testWebService" protocol="2" url_ref="url_a" timeout="60" prop_ref="prop_a" />


### PR DESCRIPTION
Since the the TMProtocolDefinition file is used on IIS where the default port 80 is applied,
Hence we have removed the port number from the web service URL links.